### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,4 +48,5 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-openapi-msbuild
     secrets: inherit


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/publish.yml` file. The change adds a new parameter to the reusable workflow configuration.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R51): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-openapi-msbuild` to the workflow configuration, specifying the entity or tag for the deployment process.